### PR TITLE
Several updates

### DIFF
--- a/moon-openshift.yaml
+++ b/moon-openshift.yaml
@@ -240,102 +240,102 @@ objects:
             "versions": {
               "74.0": {
                 "image": "selenoid/vnc_firefox:74.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "73.0": {
                 "image": "selenoid/vnc_firefox:73.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "72.0": {
                 "image": "selenoid/vnc_firefox:72.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "71.0": {
                 "image": "selenoid/vnc_firefox:71.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "70.0": {
                 "image": "selenoid/vnc_firefox:70.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "69.0": {
                 "image": "selenoid/vnc_firefox:69.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "68.0": {
                 "image": "selenoid/vnc_firefox:68.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "67.0": {
                 "image": "selenoid/vnc_firefox:67.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "66.0": {
                 "image": "selenoid/vnc_firefox:66.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "65.0": {
                 "image": "selenoid/vnc_firefox:65.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "64.0": {
                 "image": "selenoid/vnc_firefox:64.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "63.0": {
                 "image": "selenoid/vnc_firefox:63.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "62.0": {
                 "image": "selenoid/vnc_firefox:62.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "61.0": {
                 "image": "selenoid/vnc_firefox:61.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "60.0": {
                 "image": "selenoid/vnc_firefox:60.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "59.0": {
                 "image": "selenoid/vnc_firefox:59.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "58.0": {
                 "image": "selenoid/vnc_firefox:58.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "57.0": {
                 "image": "selenoid/vnc_firefox:57.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "56.0": {
                 "image": "selenoid/vnc_firefox:56.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "55.0": {
                 "image": "selenoid/vnc_firefox:55.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "54.0": {
@@ -345,257 +345,257 @@ objects:
               },
               "53.0": {
                 "image": "selenoid/vnc_firefox:53.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "52.0": {
                 "image": "selenoid/vnc_firefox:52.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "51.0": {
                 "image": "selenoid/vnc_firefox:51.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "50.0": {
                 "image": "selenoid/vnc_firefox:50.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "49.0": {
                 "image": "selenoid/vnc_firefox:49.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "48.0": {
                 "image": "selenoid/vnc_firefox:48.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "47.0": {
                 "image": "selenoid/vnc_firefox:47.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "46.0": {
                 "image": "selenoid/vnc_firefox:46.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "45.0": {
                 "image": "selenoid/vnc_firefox:45.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "44.0": {
                 "image": "selenoid/vnc_firefox:44.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "43.0": {
                 "image": "selenoid/vnc_firefox:43.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "42.0": {
                 "image": "selenoid/vnc_firefox:42.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "41.0": {
                 "image": "selenoid/vnc_firefox:41.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "40.0": {
                 "image": "selenoid/vnc_firefox:40.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "39.0": {
                 "image": "selenoid/vnc_firefox:39.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "38.0": {
                 "image": "selenoid/vnc_firefox:38.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "37.0": {
                 "image": "selenoid/vnc_firefox:37.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "36.0": {
                 "image": "selenoid/vnc_firefox:36.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "35.0": {
                 "image": "selenoid/vnc_firefox:35.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "34.0": {
                 "image": "selenoid/vnc_firefox:34.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "33.0": {
                 "image": "selenoid/vnc_firefox:33.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "32.0": {
                 "image": "selenoid/vnc_firefox:32.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "31.0": {
                 "image": "selenoid/vnc_firefox:31.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "30.0": {
                 "image": "selenoid/vnc_firefox:30.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "29.0": {
                 "image": "selenoid/vnc_firefox:29.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "28.0": {
                 "image": "selenoid/vnc_firefox:28.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "27.0": {
                 "image": "selenoid/vnc_firefox:27.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "26.0": {
                 "image": "selenoid/vnc_firefox:26.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "25.0": {
                 "image": "selenoid/vnc_firefox:25.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "24.0": {
                 "image": "selenoid/vnc_firefox:24.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "23.0": {
                 "image": "selenoid/vnc_firefox:23.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "22.0": {
                 "image": "selenoid/vnc_firefox:22.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "21.0": {
                 "image": "selenoid/vnc_firefox:21.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "20.0": {
                 "image": "selenoid/vnc_firefox:20.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "19.0": {
                 "image": "selenoid/vnc_firefox:19.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "18.0": {
                 "image": "selenoid/vnc_firefox:18.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "17.0": {
                 "image": "selenoid/vnc_firefox:17.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "16.0": {
                 "image": "selenoid/vnc_firefox:16.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "15.0": {
                 "image": "selenoid/vnc_firefox:15.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "14.0": {
                 "image": "selenoid/vnc_firefox:14.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "13.0": {
                 "image": "selenoid/vnc_firefox:13.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "12.0": {
                 "image": "selenoid/vnc_firefox:12.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "11.0": {
                 "image": "selenoid/vnc_firefox:11.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "10.0": {
                 "image": "selenoid/vnc_firefox:10.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "9.0": {
                 "image": "selenoid/vnc_firefox:9.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "8.0": {
                 "image": "selenoid/vnc_firefox:8.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "7.0": {
                 "image": "selenoid/vnc_firefox:7.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "6.0": {
                 "image": "selenoid/vnc_firefox:6.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "5.0": {
                 "image": "selenoid/vnc_firefox:5.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "4.0": {
                 "image": "selenoid/vnc_firefox:4.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "3.6": {
                 "image": "selenoid/vnc_firefox:3.6",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               }
             }

--- a/moon-openshift.yaml
+++ b/moon-openshift.yaml
@@ -9,7 +9,7 @@ objects:
       name: edit
     roleRef:
       apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
+      kind: Role
       name: edit
     subjects:
       - kind: ServiceAccount
@@ -49,6 +49,15 @@ objects:
      spec:
        selector:
          moon: browser
+       ports:
+        - name: wd
+          port: 4444
+          protocol: TCP
+          targetPort: 4444
+        - name: vnc
+          port: 5900
+          protocol: TCP
+          targetPort: 5900
        clusterIP: None
        publishNotReadyAddresses: true
 #       ports: # Uncomment the following lines if you have Openshift based on Kubernetes <1.13

--- a/moon-openshift.yaml
+++ b/moon-openshift.yaml
@@ -240,362 +240,362 @@ objects:
             "versions": {
               "74.0": {
                 "image": "selenoid/vnc_firefox:74.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "73.0": {
                 "image": "selenoid/vnc_firefox:73.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "72.0": {
                 "image": "selenoid/vnc_firefox:72.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "71.0": {
                 "image": "selenoid/vnc_firefox:71.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "70.0": {
                 "image": "selenoid/vnc_firefox:70.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "69.0": {
                 "image": "selenoid/vnc_firefox:69.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "68.0": {
                 "image": "selenoid/vnc_firefox:68.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "67.0": {
                 "image": "selenoid/vnc_firefox:67.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "66.0": {
                 "image": "selenoid/vnc_firefox:66.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "65.0": {
                 "image": "selenoid/vnc_firefox:65.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "64.0": {
                 "image": "selenoid/vnc_firefox:64.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "63.0": {
                 "image": "selenoid/vnc_firefox:63.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "62.0": {
                 "image": "selenoid/vnc_firefox:62.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "61.0": {
                 "image": "selenoid/vnc_firefox:61.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "60.0": {
                 "image": "selenoid/vnc_firefox:60.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "59.0": {
                 "image": "selenoid/vnc_firefox:59.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "58.0": {
                 "image": "selenoid/vnc_firefox:58.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "57.0": {
                 "image": "selenoid/vnc_firefox:57.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "56.0": {
                 "image": "selenoid/vnc_firefox:56.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "55.0": {
                 "image": "selenoid/vnc_firefox:55.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "54.0": {
                 "image": "selenoid/vnc_firefox:54.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "53.0": {
                 "image": "selenoid/vnc_firefox:53.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "52.0": {
                 "image": "selenoid/vnc_firefox:52.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "51.0": {
                 "image": "selenoid/vnc_firefox:51.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "50.0": {
                 "image": "selenoid/vnc_firefox:50.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "49.0": {
                 "image": "selenoid/vnc_firefox:49.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "48.0": {
                 "image": "selenoid/vnc_firefox:48.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "47.0": {
                 "image": "selenoid/vnc_firefox:47.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "46.0": {
                 "image": "selenoid/vnc_firefox:46.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "45.0": {
                 "image": "selenoid/vnc_firefox:45.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "44.0": {
                 "image": "selenoid/vnc_firefox:44.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "43.0": {
                 "image": "selenoid/vnc_firefox:43.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "42.0": {
                 "image": "selenoid/vnc_firefox:42.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "41.0": {
                 "image": "selenoid/vnc_firefox:41.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "40.0": {
                 "image": "selenoid/vnc_firefox:40.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "39.0": {
                 "image": "selenoid/vnc_firefox:39.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "38.0": {
                 "image": "selenoid/vnc_firefox:38.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "37.0": {
                 "image": "selenoid/vnc_firefox:37.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "36.0": {
                 "image": "selenoid/vnc_firefox:36.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "35.0": {
                 "image": "selenoid/vnc_firefox:35.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "34.0": {
                 "image": "selenoid/vnc_firefox:34.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "33.0": {
                 "image": "selenoid/vnc_firefox:33.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "32.0": {
                 "image": "selenoid/vnc_firefox:32.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "31.0": {
                 "image": "selenoid/vnc_firefox:31.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "30.0": {
                 "image": "selenoid/vnc_firefox:30.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "29.0": {
                 "image": "selenoid/vnc_firefox:29.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "28.0": {
                 "image": "selenoid/vnc_firefox:28.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "27.0": {
                 "image": "selenoid/vnc_firefox:27.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "26.0": {
                 "image": "selenoid/vnc_firefox:26.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "25.0": {
                 "image": "selenoid/vnc_firefox:25.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "24.0": {
                 "image": "selenoid/vnc_firefox:24.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "23.0": {
                 "image": "selenoid/vnc_firefox:23.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "22.0": {
                 "image": "selenoid/vnc_firefox:22.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "21.0": {
                 "image": "selenoid/vnc_firefox:21.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "20.0": {
                 "image": "selenoid/vnc_firefox:20.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "19.0": {
                 "image": "selenoid/vnc_firefox:19.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "18.0": {
                 "image": "selenoid/vnc_firefox:18.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "17.0": {
                 "image": "selenoid/vnc_firefox:17.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "16.0": {
                 "image": "selenoid/vnc_firefox:16.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "15.0": {
                 "image": "selenoid/vnc_firefox:15.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "14.0": {
                 "image": "selenoid/vnc_firefox:14.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "13.0": {
                 "image": "selenoid/vnc_firefox:13.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "12.0": {
                 "image": "selenoid/vnc_firefox:12.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "11.0": {
                 "image": "selenoid/vnc_firefox:11.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "10.0": {
                 "image": "selenoid/vnc_firefox:10.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "9.0": {
                 "image": "selenoid/vnc_firefox:9.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "8.0": {
                 "image": "selenoid/vnc_firefox:8.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "7.0": {
                 "image": "selenoid/vnc_firefox:7.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "6.0": {
                 "image": "selenoid/vnc_firefox:6.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "5.0": {
                 "image": "selenoid/vnc_firefox:5.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "4.0": {
                 "image": "selenoid/vnc_firefox:4.0",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               },
               "3.6": {
                 "image": "selenoid/vnc_firefox:3.6",
-                "port": "4444",
+                "port": "4444"
                 "path": "/wd/hub"
               }
             }
@@ -617,153 +617,123 @@ objects:
               },
               "77.0": {
                 "image": "selenoid/vnc_chrome:77.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "76.0": {
                 "image": "selenoid/vnc_chrome:76.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "75.0": {
                 "image": "selenoid/vnc_chrome:75.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "74.0": {
                 "image": "selenoid/vnc_chrome:74.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "73.0": {
                 "image": "selenoid/vnc_chrome:73.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "72.0": {
                 "image": "selenoid/vnc_chrome:72.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "71.0": {
                 "image": "selenoid/vnc_chrome:71.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "70.0": {
                 "image": "selenoid/vnc_chrome:70.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "69.0": {
                 "image": "selenoid/vnc_chrome:69.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "68.0": {
                 "image": "selenoid/vnc_chrome:68.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "67.0": {
                 "image": "selenoid/vnc_chrome:67.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "66.0": {
                 "image": "selenoid/vnc_chrome:66.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "65.0": {
                 "image": "selenoid/vnc_chrome:65.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "64.0": {
                 "image": "selenoid/vnc_chrome:64.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "63.0": {
                 "image": "selenoid/vnc_chrome:63.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "62.0": {
                 "image": "selenoid/vnc_chrome:62.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "61.0": {
                 "image": "selenoid/vnc_chrome:61.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "60.0": {
                 "image": "selenoid/vnc_chrome:60.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "59.0": {
                 "image": "selenoid/vnc_chrome:59.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "58.0": {
                 "image": "selenoid/vnc_chrome:58.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "57.0": {
                 "image": "selenoid/vnc_chrome:57.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "56.0": {
                 "image": "selenoid/vnc_chrome:56.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "55.0": {
                 "image": "selenoid/vnc_chrome:55.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "54.0": {
                 "image": "selenoid/vnc_chrome:54.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "53.0": {
                 "image": "selenoid/vnc_chrome:53.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "52.0": {
                 "image": "selenoid/vnc_chrome:52.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "51.0": {
                 "image": "selenoid/vnc_chrome:51.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "50.0": {
                 "image": "selenoid/vnc_chrome:50.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "49.0": {
                 "image": "selenoid/vnc_chrome:49.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "48.0": {
                 "image": "selenoid/vnc_chrome:48.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               }
             }
           },
@@ -772,173 +742,139 @@ objects:
             "versions": {
               "67.0": {
                 "image": "selenoid/vnc_opera:67.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "66.0": {
                 "image": "selenoid/vnc_opera:66.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "65.0": {
                 "image": "selenoid/vnc_opera:65.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "64.0": {
                 "image": "selenoid/vnc_opera:64.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "63.0": {
                 "image": "selenoid/vnc_opera:63.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "62.0": {
                 "image": "selenoid/vnc_opera:62.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "60.0": {
                 "image": "selenoid/vnc_opera:60.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "58.0": {
                 "image": "selenoid/vnc_opera:58.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "57.0": {
                 "image": "selenoid/vnc_opera:57.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "56.0": {
                 "image": "selenoid/vnc_opera:56.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "55.0": {
                 "image": "selenoid/vnc_opera:55.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "54.0": {
                 "image": "selenoid/vnc_opera:54.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "53.0": {
                 "image": "selenoid/vnc_opera:53.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "52.0": {
                 "image": "selenoid/vnc_opera:52.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "51.0": {
                 "image": "selenoid/vnc_opera:51.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "50.0": {
                 "image": "selenoid/vnc_opera:50.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "49.0": {
                 "image": "selenoid/vnc_opera:49.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "48.0": {
                 "image": "selenoid/vnc_opera:48.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "47.0": {
                 "image": "selenoid/vnc_opera:47.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "46.0": {
                 "image": "selenoid/vnc_opera:46.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "45.0": {
                 "image": "selenoid/vnc_opera:45.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "44.0": {
                 "image": "selenoid/vnc_opera:44.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "43.0": {
                 "image": "selenoid/vnc_opera:43.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "42.0": {
                 "image": "selenoid/vnc_opera:42.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "41.0": {
                 "image": "selenoid/vnc_opera:41.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "40.0": {
                 "image": "selenoid/vnc_opera:40.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "39.0": {
                 "image": "selenoid/vnc_opera:39.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "38.0": {
                 "image": "selenoid/vnc_opera:38.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "37.0": {
                 "image": "selenoid/vnc_opera:37.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "36.0": {
                 "image": "selenoid/vnc_opera:36.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "35.0": {
                 "image": "selenoid/vnc_opera:35.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "34.0": {
                 "image": "selenoid/vnc_opera:34.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "33.0": {
                 "image": "selenoid/vnc_opera:33.0",
-                "port": "4444",
-                "privileged": true
+                "port": "4444"
               },
               "12.16": {
                 "image": "selenoid/vnc:opera_12.16",
                 "port": "4444",
-                "privileged": true,
                 "path": "/wd/hub"
               }
             }

--- a/moon-openshift.yaml
+++ b/moon-openshift.yaml
@@ -617,123 +617,153 @@ objects:
               },
               "77.0": {
                 "image": "selenoid/vnc_chrome:77.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "76.0": {
                 "image": "selenoid/vnc_chrome:76.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "75.0": {
                 "image": "selenoid/vnc_chrome:75.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "74.0": {
                 "image": "selenoid/vnc_chrome:74.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "73.0": {
                 "image": "selenoid/vnc_chrome:73.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "72.0": {
                 "image": "selenoid/vnc_chrome:72.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "71.0": {
                 "image": "selenoid/vnc_chrome:71.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "70.0": {
                 "image": "selenoid/vnc_chrome:70.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "69.0": {
                 "image": "selenoid/vnc_chrome:69.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "68.0": {
                 "image": "selenoid/vnc_chrome:68.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "67.0": {
                 "image": "selenoid/vnc_chrome:67.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "66.0": {
                 "image": "selenoid/vnc_chrome:66.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "65.0": {
                 "image": "selenoid/vnc_chrome:65.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "64.0": {
                 "image": "selenoid/vnc_chrome:64.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "63.0": {
                 "image": "selenoid/vnc_chrome:63.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "62.0": {
                 "image": "selenoid/vnc_chrome:62.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "61.0": {
                 "image": "selenoid/vnc_chrome:61.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "60.0": {
                 "image": "selenoid/vnc_chrome:60.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "59.0": {
                 "image": "selenoid/vnc_chrome:59.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "58.0": {
                 "image": "selenoid/vnc_chrome:58.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "57.0": {
                 "image": "selenoid/vnc_chrome:57.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "56.0": {
                 "image": "selenoid/vnc_chrome:56.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "55.0": {
                 "image": "selenoid/vnc_chrome:55.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "54.0": {
                 "image": "selenoid/vnc_chrome:54.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "53.0": {
                 "image": "selenoid/vnc_chrome:53.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "52.0": {
                 "image": "selenoid/vnc_chrome:52.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "51.0": {
                 "image": "selenoid/vnc_chrome:51.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "50.0": {
                 "image": "selenoid/vnc_chrome:50.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "49.0": {
                 "image": "selenoid/vnc_chrome:49.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "48.0": {
                 "image": "selenoid/vnc_chrome:48.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               }
             }
           },
@@ -742,139 +772,173 @@ objects:
             "versions": {
               "67.0": {
                 "image": "selenoid/vnc_opera:67.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "66.0": {
                 "image": "selenoid/vnc_opera:66.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "65.0": {
                 "image": "selenoid/vnc_opera:65.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "64.0": {
                 "image": "selenoid/vnc_opera:64.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "63.0": {
                 "image": "selenoid/vnc_opera:63.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "62.0": {
                 "image": "selenoid/vnc_opera:62.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "60.0": {
                 "image": "selenoid/vnc_opera:60.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "58.0": {
                 "image": "selenoid/vnc_opera:58.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "57.0": {
                 "image": "selenoid/vnc_opera:57.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "56.0": {
                 "image": "selenoid/vnc_opera:56.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "55.0": {
                 "image": "selenoid/vnc_opera:55.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "54.0": {
                 "image": "selenoid/vnc_opera:54.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "53.0": {
                 "image": "selenoid/vnc_opera:53.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "52.0": {
                 "image": "selenoid/vnc_opera:52.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "51.0": {
                 "image": "selenoid/vnc_opera:51.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "50.0": {
                 "image": "selenoid/vnc_opera:50.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "49.0": {
                 "image": "selenoid/vnc_opera:49.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "48.0": {
                 "image": "selenoid/vnc_opera:48.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "47.0": {
                 "image": "selenoid/vnc_opera:47.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "46.0": {
                 "image": "selenoid/vnc_opera:46.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "45.0": {
                 "image": "selenoid/vnc_opera:45.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "44.0": {
                 "image": "selenoid/vnc_opera:44.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "43.0": {
                 "image": "selenoid/vnc_opera:43.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "42.0": {
                 "image": "selenoid/vnc_opera:42.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "41.0": {
                 "image": "selenoid/vnc_opera:41.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "40.0": {
                 "image": "selenoid/vnc_opera:40.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "39.0": {
                 "image": "selenoid/vnc_opera:39.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "38.0": {
                 "image": "selenoid/vnc_opera:38.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "37.0": {
                 "image": "selenoid/vnc_opera:37.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "36.0": {
                 "image": "selenoid/vnc_opera:36.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "35.0": {
                 "image": "selenoid/vnc_opera:35.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "34.0": {
                 "image": "selenoid/vnc_opera:34.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "33.0": {
                 "image": "selenoid/vnc_opera:33.0",
-                "port": "4444"
+                "port": "4444",
+                "privileged": true
               },
               "12.16": {
                 "image": "selenoid/vnc:opera_12.16",
                 "port": "4444",
+                "privileged": true,
                 "path": "/wd/hub"
               }
             }

--- a/moon-openshift.yaml
+++ b/moon-openshift.yaml
@@ -340,7 +340,7 @@ objects:
               },
               "54.0": {
                 "image": "selenoid/vnc_firefox:54.0",
-                "port": "4444"
+                "port": "4444",
                 "path": "/wd/hub"
               },
               "53.0": {


### PR DESCRIPTION
- Change ClusterRole to Role (you don't need ClusterRole for your SA for this deployment because moon start pods in his own namespace\project)
- Add ports for service `browser` because without it started pods can't receive income traffic (for OKD\openshift 3.11 it's true)
- ~~Add privileged mode for chromium-based pods~~