### PR TITLE
Use NAMESPACE parameter for namespace

### DIFF
--- a/moon-openshift.yaml
+++ b/moon-openshift.yaml
@@ -45,7 +45,7 @@ objects:
     kind: Service
     metadata:
       name: browsers
-      namespace: moon
+      namespace: ${NAMESPACE}
     spec:
       selector:
         moon: browser
@@ -76,7 +76,7 @@ objects:
 #      annotations:
 #        kubernetes.io/ingress.class: nginx
 #      name: moon
-#      namespace: moon
+#      namespace: ${NAMESPACE}
 #    spec:
 #      rules:
 #        - host: moon.example.com # Replace with correct cluster FQDN
@@ -240,7 +240,7 @@ objects:
     apiVersion: v1
     metadata:
       name: config
-      namespace: moon
+      namespace: ${NAMESPACE}
     data:
       service.json: |
         {


### PR DESCRIPTION
Hello,

I found a few places in the openshift template where the namespace is hardcoded to `moon`. It seems to me that we should use the NAMESPACE parameter there?

Cheers,
Sylvain